### PR TITLE
Connection Pooling & Threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ Available configuration fields are as follows:
  Database (Optional)      | Specifies the default database to use once connected. 
  Schema (Optional)        | Specifies the default schema to use for the specified database once connected. 
  Extra Options (Optional) | Specifies a series of one or more parameters, in the form of `<param>=<value>`, with each parameter separated by the ampersand character (&), and no spaces anywhere in the connection string. 
+ max. open Connections    | How many connections to snowflake are opened at a time. If the limit of open connections is exceeded newer queries will be cached in the queue. [default: 100]
+ max. queued Queries      | Queue size of the internal query queue. If this limit is exceeded the query will be dropped and and error is thrown. Should always be higher as `max. open Connections`. 0 to disable. [default: 400] 
+ Connection lifetime      | Time in minutes until unnused connections are recycled. [default: 60min]
 
 #### Supported Macros
 

--- a/pkg/check_health.go
+++ b/pkg/check_health.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
@@ -15,18 +14,12 @@ import (
 // a datasource is working as expected.
 func (td *SnowflakeDatasource) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
 
-	connectionString, result := createAndValidationConnectionString(req)
-	if result != nil {
-		return result, nil
-	}
-	db, err := sql.Open("snowflake", connectionString)
+	i, err := td.im.Get(ctx, req.PluginContext)
 	if err != nil {
-		return &backend.CheckHealthResult{
-			Status:  backend.HealthStatusError,
-			Message: fmt.Sprintf("Connection issue : %s", err),
-		}, nil
+		return nil, err
 	}
-	defer db.Close()
+	instance := i.(*instanceSettings)
+	db := instance.db
 
 	row, err := db.QueryContext(ctx, "SELECT 1")
 	if err != nil {

--- a/pkg/query.go
+++ b/pkg/query.go
@@ -4,11 +4,15 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math/big"
 	"reflect"
+	"runtime/debug"
 	"strconv"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
@@ -25,6 +29,20 @@ func (qc *queryConfigStruct) isTimeSeriesType() bool {
 	return qc.QueryType == timeSeriesType
 }
 
+type queryCounter int32
+
+func (c *queryCounter) inc() int32 {
+	return atomic.AddInt32((*int32)(c), 1)
+}
+
+func (c *queryCounter) dec() int32 {
+	return atomic.AddInt32((*int32)(c), -1)
+}
+
+func (c *queryCounter) get() int32 {
+	return atomic.LoadInt32((*int32)(c))
+}
+
 type queryConfigStruct struct {
 	FinalQuery    string
 	QueryType     string
@@ -35,6 +53,9 @@ type queryConfigStruct struct {
 	MaxDataPoints int64
 	FillMode      string
 	FillValue     float64
+	db            *sql.DB
+	config        *pluginConfig
+	actQueryCount *queryCounter
 }
 
 // type
@@ -58,22 +79,26 @@ type queryModel struct {
 	FillMode    string   `json:"fillMode"`
 }
 
-func (qc *queryConfigStruct) fetchData(ctx context.Context, config *pluginConfig, password string, privateKey string) (result DataQueryResult, err error) {
+func (qc *queryConfigStruct) fetchData(ctx context.Context) (result DataQueryResult, err error) {
+	qc.actQueryCount.inc()
 	// Custom configuration to reduce memory footprint
 	sf.MaxChunkDownloadWorkers = 2
 	sf.CustomJSONDecoderEnabled = true
 
-	connectionString := getConnectionString(config, password, privateKey)
+	start := time.Now()
+	stats := qc.db.Stats()
+	defer func() {
+		qc.actQueryCount.dec()
+		duration := time.Since(start)
+		log.DefaultLogger.Info(fmt.Sprintf("%+v - %s - %d", stats, duration, int(qc.actQueryCount.get())))
 
-	db, err := sql.Open("snowflake", connectionString)
-	if err != nil {
-		log.DefaultLogger.Error("Could not open database", "err", err)
+	}()
+	if int(qc.config.IntMaxQueuedQueries) > 0 && int(qc.actQueryCount.get()) >= (int(qc.config.IntMaxQueuedQueries)) {
+		err := errors.New("too many queries in queue. Check Snowflake connectivity or increase MaxQueuedQeries count")
+		log.DefaultLogger.Error("Poolsize exceeded", "query", qc.FinalQuery, "err", err)
 		return result, err
 	}
-	defer db.Close()
-
-	log.DefaultLogger.Info("Query", "finalQuery", qc.FinalQuery)
-	rows, err := db.QueryContext(ctx, qc.FinalQuery)
+	rows, err := qc.db.QueryContext(ctx, qc.FinalQuery)
 	if err != nil {
 		if strings.Contains(err.Error(), "000605") {
 			log.DefaultLogger.Info("Query got cancelled", "query", qc.FinalQuery, "err", err)
@@ -83,7 +108,11 @@ func (qc *queryConfigStruct) fetchData(ctx context.Context, config *pluginConfig
 		log.DefaultLogger.Error("Could not execute query", "query", qc.FinalQuery, "err", err)
 		return result, err
 	}
-	defer rows.Close()
+	defer func() {
+		if err := rows.Close(); err != nil {
+			log.DefaultLogger.Warn("Failed to close rows", "err", err)
+		}
+	}()
 
 	columnTypes, err := rows.ColumnTypes()
 	if err != nil {
@@ -185,19 +214,39 @@ func (qc *queryConfigStruct) transformQueryResult(columnTypes []*sql.ColumnType,
 	return values, nil
 }
 
-func (td *SnowflakeDatasource) query(ctx context.Context, dataQuery backend.DataQuery, config pluginConfig, password string, privateKey string) (response backend.DataResponse) {
+func (td *SnowflakeDatasource) query(ctx context.Context, wg *sync.WaitGroup, ch chan DBDataResponse, instance *instanceSettings, dataQuery backend.DataQuery) {
+	defer wg.Done()
+	queryResult := DBDataResponse{
+		dataResponse: backend.DataResponse{},
+		refID:        dataQuery.RefID,
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			log.DefaultLogger.Error("ExecuteQuery panic", "error", r, "stack", string(debug.Stack()))
+			if theErr, ok := r.(error); ok {
+				queryResult.dataResponse.Error = theErr
+			} else if theErrString, ok := r.(string); ok {
+				queryResult.dataResponse.Error = fmt.Errorf(theErrString)
+			} else {
+				//queryResult.dataResponse.Error = fmt.Errorf("unexpected error - %s", td.userError)
+			}
+			ch <- queryResult
+		}
+	}()
+
 	var qm queryModel
 	err := json.Unmarshal(dataQuery.JSON, &qm)
 	if err != nil {
-		log.DefaultLogger.Error("Could not unmarshal query", "err", err)
-		response.Error = err
-		return response
+		//log.DefaultLogger.Error("Could not unmarshal query", "err", err)
+		//queryResult.dataResponse.Error = err
+		panic("Could not unmarshal query")
 	}
 
 	if qm.QueryText == "" {
-		log.DefaultLogger.Error("SQL query must no be empty")
-		response.Error = fmt.Errorf("SQL query must no be empty")
-		return response
+		//log.DefaultLogger.Error("SQL query must no be empty")
+		//queryResult.dataResponse.Error = fmt.Errorf("SQL query must no be empty")
+		panic("Query model property rawSql should not be empty at this point")
 	}
 
 	queryConfig := queryConfigStruct{
@@ -209,32 +258,44 @@ func (td *SnowflakeDatasource) query(ctx context.Context, dataQuery backend.Data
 		Interval:      dataQuery.Interval,
 		TimeRange:     dataQuery.TimeRange,
 		MaxDataPoints: dataQuery.MaxDataPoints,
+		db:            instance.db,
+		config:        instance.config,
+		actQueryCount: &td.actQueryCount,
 	}
 
-	log.DefaultLogger.Info("Query config", "config", qm)
+	errAppendDebug := func(frameErr string, err error, query string) {
+		var emptyFrame data.Frame
+		emptyFrame.SetMeta(&data.FrameMeta{
+			ExecutedQueryString: query,
+		})
+		queryResult.dataResponse.Error = fmt.Errorf("%s: %w", frameErr, err)
+		queryResult.dataResponse.Frames = data.Frames{&emptyFrame}
+		ch <- queryResult
+	}
 
 	// Apply macros
 	queryConfig.FinalQuery, err = Interpolate(&queryConfig)
 	if err != nil {
-		response.Error = err
-		return response
+		errAppendDebug("interpolation failed", err, queryConfig.FinalQuery)
+		return
 	}
 
 	// Remove final semi column
 	queryConfig.FinalQuery = strings.TrimSuffix(strings.TrimSpace(queryConfig.FinalQuery), ";")
 
 	frame := data.NewFrame("")
-	dataResponse, err := queryConfig.fetchData(ctx, &config, password, privateKey)
+	dataResponse, err := queryConfig.fetchData(ctx)
 	if err != nil {
-		response.Error = err
-		return response
+		errAppendDebug("db query error", err, queryConfig.FinalQuery)
+		return
 	}
 	log.DefaultLogger.Debug("Response", "data", dataResponse)
 	for _, table := range dataResponse.Tables {
 		timeColumnIndex := -1
 		for i, column := range table.Columns {
 			if err != nil {
-				return backend.DataResponse{}
+				errAppendDebug("db query error", err, queryConfig.FinalQuery)
+				return
 			}
 			// Check time column
 			if queryConfig.isTimeSeriesType() && equalsIgnoreCase(queryConfig.TimeColumns, column.Name()) {
@@ -294,9 +355,8 @@ func (td *SnowflakeDatasource) query(ctx context.Context, dataQuery backend.Data
 		ExecutedQueryString: queryConfig.FinalQuery,
 	}
 
-	response.Frames = append(response.Frames, frame)
-
-	return response
+	queryResult.dataResponse.Frames = data.Frames{frame}
+	ch <- queryResult
 }
 
 func (td *SnowflakeDatasource) longToWide(frame *data.Frame, queryConfig queryConfigStruct, dataResponse DataQueryResult, err error) *data.Frame {

--- a/pkg/snowflake.go
+++ b/pkg/snowflake.go
@@ -2,8 +2,12 @@ package main
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
+	"strconv"
+	"sync"
+	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/datasource"
@@ -12,6 +16,11 @@ import (
 
 	"net/url"
 )
+
+type DBDataResponse struct {
+	dataResponse backend.DataResponse
+	refID        string
+}
 
 // newDatasource returns datasource.ServeOpts.
 func newDatasource() datasource.ServeOpts {
@@ -33,7 +42,8 @@ type SnowflakeDatasource struct {
 	// The instance manager can help with lifecycle management
 	// of datasource instances in plugins. It's not a requirements
 	// but a best practice that we recommend that you follow.
-	im instancemgmt.InstanceManager
+	im            instancemgmt.InstanceManager
+	actQueryCount queryCounter
 }
 
 // QueryData handles multiple queries and returns multiple responses.
@@ -43,40 +53,85 @@ type SnowflakeDatasource struct {
 func (td *SnowflakeDatasource) QueryData(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
 
 	// create response struct
-	response := backend.NewQueryDataResponse()
+	result := backend.NewQueryDataResponse()
 
-	password := req.PluginContext.DataSourceInstanceSettings.DecryptedSecureJSONData["password"]
+	/*password := req.PluginContext.DataSourceInstanceSettings.DecryptedSecureJSONData["password"]
 	privateKey := req.PluginContext.DataSourceInstanceSettings.DecryptedSecureJSONData["privateKey"]
 
 	config, err := getConfig(req.PluginContext.DataSourceInstanceSettings)
 	if err != nil {
 		log.DefaultLogger.Error("Could not get config for plugin", "err", err)
 		return response, err
+	}*/
+	i, err := td.im.Get(ctx, req.PluginContext)
+	if err != nil {
+		return nil, err
+	}
+	instance := i.(*instanceSettings)
+	ch := make(chan DBDataResponse, len(req.Queries))
+	var wg sync.WaitGroup
+	// Execute each query in a goroutine and wait for them to finish afterwards
+	for _, query := range req.Queries {
+		wg.Add(1)
+		go td.query(ctx, &wg, ch, instance, query)
+		//go e.executeQuery(query, &wg, ctx, ch, queryjson)
 	}
 
-	// loop over queries and execute them individually.
-	for _, q := range req.Queries {
-		// save the response in a hashmap
-		// based on with RefID as identifier
-		response.Responses[q.RefID] = td.query(ctx, q, config, password, privateKey)
+	wg.Wait()
+
+	// Read results from channels
+	close(ch)
+	result.Responses = make(map[string]backend.DataResponse)
+	for queryResult := range ch {
+		result.Responses[queryResult.refID] = queryResult.dataResponse
 	}
 
-	return response, nil
+	return result, nil
 }
 
 type pluginConfig struct {
-	Account     string `json:"account"`
-	Username    string `json:"username"`
-	Role        string `json:"role"`
-	Warehouse   string `json:"warehouse"`
-	Database    string `json:"database"`
-	Schema      string `json:"schema"`
-	ExtraConfig string `json:"extraConfig"`
+	Account               string `json:"account"`
+	Username              string `json:"username"`
+	Role                  string `json:"role"`
+	Warehouse             string `json:"warehouse"`
+	Database              string `json:"database"`
+	Schema                string `json:"schema"`
+	ExtraConfig           string `json:"extraConfig"`
+	MaxOpenConnections    string `json:"maxOpenConnections"`
+	IntMaxOpenConnections int64
+	MaxQueuedQueries      string `json:"maxQueuedQueries"`
+	IntMaxQueuedQueries   int64
+	ConnectionLifetime    string `json:"connectionLifetime"`
+	IntConnectionLifetime int64
 }
 
 func getConfig(settings *backend.DataSourceInstanceSettings) (pluginConfig, error) {
 	var config pluginConfig
 	err := json.Unmarshal(settings.JSONData, &config)
+	if config.MaxOpenConnections == "" {
+		config.MaxOpenConnections = "100"
+	}
+	if config.ConnectionLifetime == "" {
+		config.ConnectionLifetime = "60"
+	}
+	if config.MaxQueuedQueries == "" {
+		config.MaxQueuedQueries = "400"
+	}
+	if MaxOpenConnections, err := strconv.Atoi(config.MaxOpenConnections); err == nil {
+		config.IntMaxOpenConnections = int64(MaxOpenConnections)
+	} else {
+		return config, err
+	}
+	if ConnectionLifetime, err := strconv.Atoi(config.ConnectionLifetime); err == nil {
+		config.IntConnectionLifetime = int64(ConnectionLifetime)
+	} else {
+		return config, err
+	}
+	if MaxQueuedQueries, err := strconv.Atoi(config.MaxQueuedQueries); err == nil {
+		config.IntMaxQueuedQueries = int64(MaxQueuedQueries)
+	} else {
+		return config, err
+	}
 	if err != nil {
 		return config, err
 	}
@@ -103,13 +158,40 @@ func getConnectionString(config *pluginConfig, password string, privateKey strin
 }
 
 type instanceSettings struct {
+	db     *sql.DB
+	config *pluginConfig
 }
 
 func newDataSourceInstance(ctx context.Context, setting backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
+
 	log.DefaultLogger.Info("Creating instance")
-	return &instanceSettings{}, nil
+	password := setting.DecryptedSecureJSONData["password"]
+	privateKey := setting.DecryptedSecureJSONData["privateKey"]
+
+	config, err := getConfig(&setting)
+	if err != nil {
+		log.DefaultLogger.Error("Could not get config for plugin", "err", err)
+		return nil, err
+	}
+
+	connectionString := getConnectionString(&config, password, privateKey)
+	db, err := sql.Open("snowflake", connectionString)
+	if err != nil {
+		return nil, err
+	}
+
+	db.SetMaxOpenConns(int(config.IntMaxOpenConnections))
+	db.SetMaxIdleConns(int(config.IntMaxOpenConnections))
+	db.SetConnMaxLifetime(time.Duration(int(config.IntConnectionLifetime)) * time.Minute)
+	return &instanceSettings{db: db, config: &config}, nil
 }
 
 func (s *instanceSettings) Dispose() {
 	log.DefaultLogger.Info("Disposing of instance")
+	if s.db != nil {
+		if err := s.db.Close(); err != nil {
+			log.DefaultLogger.Error("Failed to dispose db", "error", err)
+		}
+	}
+	log.DefaultLogger.Debug("DB disposed")
 }

--- a/pkg/snowflake_test.go
+++ b/pkg/snowflake_test.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestGetConfig(t *testing.T) {
@@ -15,8 +16,8 @@ func TestGetConfig(t *testing.T) {
 		response string
 		err      string
 	}{
-		{json: "{}", config: pluginConfig{}},
-		{json: "{\"account\":\"test\"}", config: pluginConfig{Account: "test"}},
+		{json: "{}", config: pluginConfig{ConnectionLifetime: "60", IntConnectionLifetime: 60, MaxOpenConnections: "100", IntMaxOpenConnections: 100, MaxQueuedQueries: "400", IntMaxQueuedQueries: 400}},
+		{json: "{\"account\":\"test\"}", config: pluginConfig{Account: "test", ConnectionLifetime: "60", IntConnectionLifetime: 60, MaxOpenConnections: "100", IntMaxOpenConnections: 100, MaxQueuedQueries: "400", IntMaxQueuedQueries: 400}},
 		{json: "{", err: "unexpected end of JSON input"},
 	}
 	for i, tc := range tcs {

--- a/src/ConfigEditor.tsx
+++ b/src/ConfigEditor.tsx
@@ -10,6 +10,19 @@ interface Props extends DataSourcePluginOptionsEditorProps<SnowflakeOptions> { }
 interface State { }
 
 export class ConfigEditor extends PureComponent<Props, State> {
+  componentDidMount() {
+    const { onOptionsChange, options } = this.props;
+    if (options.jsonData.maxOpenConnections === ""){
+      const jsonData = {
+        ...options.jsonData,
+        maxOpenConnections: "100",
+        maxQueuedQueries:"400",
+        connectionLifetime: "60",
+        
+      };
+      onOptionsChange({ ...options, jsonData });
+    }
+  }
   onAccountChange = (event: ChangeEvent<HTMLInputElement>) => {
     const { onOptionsChange, options } = this.props;
 
@@ -76,11 +89,11 @@ export class ConfigEditor extends PureComponent<Props, State> {
     onOptionsChange({ ...options, jsonData });
   };
 
-  onAuthenticationChange = (event: React.SyntheticEvent<HTMLInputElement>) => {
+  onAuthenticationChange = (event: ChangeEvent<HTMLInputElement>) => {
     const { onOptionsChange, options } = this.props;
     const jsonData = {
       ...options.jsonData,
-      basicAuth: (event.target as HTMLInputElement).checked,
+      basicAuth: event.target.checked,
     };
     onOptionsChange({ ...options, jsonData });
   };
@@ -145,6 +158,31 @@ export class ConfigEditor extends PureComponent<Props, State> {
         privateKey: '',
       },
     });
+  };
+
+  onMaxOpenConnectionsChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const { onOptionsChange, options } = this.props;
+    const jsonData = {
+      ...options.jsonData,
+      maxOpenConnections: event.target.value,
+    };
+    onOptionsChange({ ...options, jsonData });
+  };
+  onMaxQueuedQueriesChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const { onOptionsChange, options } = this.props;
+    const jsonData = {
+      ...options.jsonData,
+      maxQueuedQueries: event.target.value,
+    };
+    onOptionsChange({ ...options, jsonData });
+  };
+  onConnectionLifetimeChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const { onOptionsChange, options } = this.props;
+    const jsonData = {
+      ...options.jsonData,
+      conectionLifetime: event.target.value,
+    };
+    onOptionsChange({ ...options, jsonData });
   };
 
   render() {
@@ -288,7 +326,44 @@ export class ConfigEditor extends PureComponent<Props, State> {
             placeholder="TIMESTAMP_OUTPUT_FORMAT=MM-DD-YYYY&XXXXX=yyyyy&..."
           />
         </InlineField>
-
+        <br />
+        <h3 className="page-heading">Connection Pool configuration</h3>
+        <InlineField
+          labelWidth={30}
+          label="max. open Connections"
+          tooltip="How many connections will be opend from the datasource to snowflake (default: 100)" >
+          <Input
+            type="number"
+            className="width-20"
+            onChange={this.onMaxOpenConnectionsChange}
+            value={jsonData.maxOpenConnections || '100'}
+            placeholder="100"
+          />
+        </InlineField>
+        <InlineField
+          labelWidth={30}
+          label="max. queued Queries"
+          tooltip='How many queries will be put into the query queue. This should be higher as "max. open Connections" when more queries as set are waiting to be executed a "too many open queries" error will be thrown. (default: 400 | 0 = no limit)' >
+          <Input
+            type="number"
+            className="width-20"
+            onChange={this.onMaxQueuedQueriesChange}
+            value={jsonData.maxQueuedQueries || '400'}
+            placeholder="400"
+          />
+        </InlineField>
+        <InlineField
+          labelWidth={30}
+          label="Connection lifetime [min]"
+          tooltip="How long open connections are hold to be reused in minutes. (default=60 | 0=never close)" >
+          <Input
+            type="number"
+            className="width-20"
+            onChange={this.onConnectionLifetimeChange}
+            value={jsonData.connectionLifetime || '60'}
+            placeholder="60"
+          />
+        </InlineField>
       </FieldSet >
     )
     

--- a/src/ConfigEditor.tsx
+++ b/src/ConfigEditor.tsx
@@ -1,13 +1,13 @@
 import React, { ChangeEvent, PureComponent } from 'react';
-import { LegacyForms } from '@grafana/ui';
+import {  InlineField, InlineSwitch, SecretInput, Input, FieldSet } from '@grafana/ui';
 import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
 import { SnowflakeOptions, SnowflakeSecureOptions } from './types';
 
-const { SecretFormField, FormField, Switch } = LegacyForms;
 
-interface Props extends DataSourcePluginOptionsEditorProps<SnowflakeOptions> {}
 
-interface State {}
+interface Props extends DataSourcePluginOptionsEditorProps<SnowflakeOptions> { }
+
+interface State { }
 
 export class ConfigEditor extends PureComponent<Props, State> {
   onAccountChange = (event: ChangeEvent<HTMLInputElement>) => {
@@ -151,127 +151,146 @@ export class ConfigEditor extends PureComponent<Props, State> {
     const { options } = this.props;
     const { jsonData, secureJsonFields } = options;
     const secureJsonData = (options.secureJsonData || {}) as SnowflakeSecureOptions;
-
     return (
-      <div className="gf-form-group">
+      <FieldSet>
         <h3 className="page-heading">Connection</h3>
-
-        <div className="gf-form">
-          <FormField
-            label="Account name"
-            labelWidth={10}
-            inputWidth={30}
-            onChange={this.onAccountChange}
-            tooltip="All access to Snowflake is either through your account name (provided by Snowflake) or a URL that uses the following format: `xxxxx.snowflakecomputing.com`"
-            value={jsonData.account || ''}
+        <InlineField
+          labelWidth={30}
+          label="Account name"
+          tooltip="All access to Snowflake is either through your account name (provided by Snowflake) or a URL that uses the following format: `xxxxx.snowflakecomputing.com`" >
+          <Input
             placeholder="xxxxxx.snowflakecomputing.com"
+            type="string"
+            className="width-30"
+            value={jsonData.account || ''}
+            onChange={this.onAccountChange}
           />
-        </div>
-
-        <div className="gf-form">
-          <FormField
-            label="Username"
-            labelWidth={10}
-            inputWidth={20}
+        </InlineField>
+        <InlineField
+          labelWidth={30}
+          label="Username"
+          tooltip="" >
+          <Input
+            placeholder="Username"
+            type="string"
+            className="width-20"
             onChange={this.onUsernameChange}
             value={jsonData.username || ''}
-            placeholder="Username"
           />
-        </div>
+        </InlineField>
+        <InlineField
+          labelWidth={30}
+          label="basic or key pair authentication"
+          tooltip="" >
+          <InlineSwitch
+                name="keyorpairauth"
+                required
+                value={jsonData.basicAuth ?? false}
+                autoComplete="off"
+                onChange={this.onAuthenticationChange}
+              />
+        </InlineField>
 
-        <div className="gf-form">
-          <Switch
-            label="basic or key pair authentication"
-            checked={jsonData.basicAuth}
-            onChange={this.onAuthenticationChange}
-          />
-        </div>
-        <div className="gf-form">
-          {!jsonData.basicAuth && (
-            <SecretFormField
+        {!jsonData.basicAuth && (
+          <InlineField
+            labelWidth={30}
+            label="Password"
+            tooltip="" >
+            <SecretInput
+              type="string"
+              className="width-20"
+              placeholder="password"
               isConfigured={(secureJsonFields && secureJsonFields.password) as boolean}
               value={secureJsonData.password || ''}
-              label="Password"
-              placeholder="password"
-              labelWidth={10}
-              inputWidth={20}
               onReset={this.onResetPassword}
               onChange={this.onPasswordChange}
             />
-          )}
-          {jsonData.basicAuth && (
-            <SecretFormField
+          </InlineField>
+        )}
+        {jsonData.basicAuth && (
+          <InlineField
+            labelWidth={30}
+            label="Private key"
+            tooltip="The private key must be encoded in base 64 URL encoded pkcs8 (remove PEM header '----- BEGIN PRIVATE KEY -----' and '----- END PRIVATE KEY -----', remove line space and replace '+' with '-' and '/' with '_')" >
+            <SecretInput
+              type="string"
+              className="width-20"
+              placeholder="MIIB..."
               isConfigured={(secureJsonFields && secureJsonFields.privateKey) as boolean}
               value={secureJsonData.privateKey || ''}
-              tooltip="The private key must be encoded in base 64 URL encoded pkcs8 (remove PEM header '----- BEGIN PRIVATE KEY -----' and '----- END PRIVATE KEY -----', remove line space and replace '+' with '-' and '/' with '_')"
-              label="Private key"
-              placeholder="MIIB..."
-              labelWidth={10}
-              inputWidth={20}
               onReset={this.onResetPrivateKey}
               onChange={this.onPrivateKeyChange}
             />
-          )}
-        </div>
-        <div className="gf-form">
-          <FormField
-            label="Role"
-            labelWidth={10}
-            inputWidth={20}
+          </InlineField>
+        )}
+        <InlineField
+          labelWidth={30}
+          label="Role"
+          tooltip="" >
+          <Input
+            type="string"
+            className="width-20"
             onChange={this.onRoleChange}
             value={jsonData.role || ''}
             placeholder="Role"
           />
-        </div>
+        </InlineField>
+       
         <br />
         <h3 className="page-heading">Parameter configuration</h3>
-
-        <div className="gf-form">
-          <FormField
-            label="Warehouse"
-            labelWidth={10}
-            inputWidth={20}
+        <InlineField
+          labelWidth={30}
+          label="Warehouse"
+          tooltip="" >
+          <Input
+            type="string"
+            className="width-20"
             onChange={this.onWarehouseChange}
             value={jsonData.warehouse || ''}
             placeholder="Default warehouse"
           />
-        </div>
-
-        <div className="gf-form">
-          <FormField
-            label="Database"
-            labelWidth={10}
-            inputWidth={20}
+        </InlineField>
+        <InlineField
+          labelWidth={30}
+          label="Database"
+          tooltip="" >
+          <Input
+            type="string"
+            className="width-20"
             onChange={this.onDatabaseChange}
             value={jsonData.database || ''}
             placeholder="Default database"
           />
-        </div>
-
-        <div className="gf-form">
-          <FormField
-            label="Schema"
-            labelWidth={10}
-            inputWidth={20}
+        </InlineField>
+        <InlineField
+          labelWidth={30}
+          label="Schema"
+          tooltip="" >
+          <Input
+            type="string"
+            className="width-20"
             onChange={this.onSchemaChange}
             value={jsonData.schema || ''}
             placeholder="Default Schema"
           />
-        </div>
+        </InlineField>
         <br />
         <h3 className="page-heading">Session configuration</h3>
-
-        <div className="gf-form">
-          <FormField
-            label="Extra options"
-            labelWidth={10}
-            inputWidth={30}
+        <InlineField
+          labelWidth={30}
+          label="Extra options"
+          tooltip="" >
+          <Input
+            type="string"
+            className="width-30"
             onChange={this.onExtraOptionChange}
             value={jsonData.extraConfig || ''}
             placeholder="TIMESTAMP_OUTPUT_FORMAT=MM-DD-YYYY&XXXXX=yyyyy&..."
           />
-        </div>
-      </div>
-    );
+        </InlineField>
+
+      </FieldSet >
+    )
+    
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,9 @@ export interface SnowflakeOptions extends DataSourceJsonData {
   schema?: string;
   extraConfig?: string;
   basicAuth: boolean;
+  maxOpenConnections?: string;
+  maxQueuedQueries?: string;
+  connectionLifetime?: string;
 }
 
 /**


### PR DESCRIPTION
This implements Connection pooling and threads for multi query Panels.

A defined poolsize is used to hold connections to snowflake. This will reduce the overhead for Login / Connection establishment for every single query. Until now a connection is dropped after each Query and has to be recreated for the next one. This change will reuse connections.
If multiple queries are configured for one panel the execution will be done in parallel. Until now the execution was in sequence.